### PR TITLE
fix: remove Markdown front matter from PR template

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,21 +1,14 @@
----
-name: Pull Request
-about: Submit a Pull Request to contribute changes
-title: ''
-labels: ''
-assignees: ''
-
----
-## Resolves
-
-_What GitHub issue does this resolve (please include link)? Please do not submit PRs that are not associated with an
-issue, or that only partially implement a fix._
-
-- Resolves #0
-
-## Proposed Changes
+# Proposed Changes
 
 _Describe what this Pull Request does._
+
+## Resolves
+
+_What GitHub issue does this resolve? If this PR fixes a bug, please link to the issue by updating the `Resolves #0`
+line below. If the bug has no associated issue, please file one first. Please do not submit bug fixes without an
+associated issue, or that only partially implement a fix._
+
+- Resolves #0
 
 ## Reason for Changes
 


### PR DESCRIPTION
# Proposed Changes

Update the PR template:
- Remove the front matter
- Slightly rearrange the sections
- Change the "Proposed Changes" section to use H1

## Reason for Changes

The front matter is annoying and potentially confusing when editing a PR description. Without it, though, `markdownlint` complains that the document should start with a top-level header. Since I'd prefer that folks be able to use `markdownlint` with minimal configuration, I wanted to make exactly one section use a top-level header. The "Proposed Changes" section made the most sense to me.
