### PR TITLE
chore: add CLAUDE.md bridge so Claude Code loads AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,11 @@ This file is a template for `AGENTS.md` files across Scratch repositories. Copy 
 replace the placeholder sections with repo-specific content. The HTML comments are standing instructions for
 whoever adapts the template — they are safe to leave in place.
 
+Claude Code reads `CLAUDE.md`, not `AGENTS.md`. So that it picks up this guide, also add a one-line `CLAUDE.md`
+next to this file whose only content is the import directive `@AGENTS.md`. Use a plain import file rather than a
+symlink — a committed symlink does not survive Windows checkouts. Other agent tools continue to read `AGENTS.md`
+directly, so this bridge adds Claude Code support without duplicating any content.
+
 When adapting this template, consider adding sections for **Repository layout** and any language- or
 framework-specific conventions (TypeScript guidelines, React patterns, testing conventions, etc.) that are
 non-obvious from the code itself.
@@ -60,6 +65,7 @@ organization. It provides org-wide GitHub defaults:
 - `CONTRIBUTING.AI.md` — Scratch's org-wide policy on AI-assisted development
 - `PULL_REQUEST_TEMPLATE.md` — default PR template
 - `AGENTS.md` (this file) — template for per-repo agent guides
+- `CLAUDE.md` — a one-line import (`@AGENTS.md`) so Claude Code, which reads `CLAUDE.md` rather than `AGENTS.md`, loads this guide
 
 There is no build step and no test suite. Changes here are prose and Markdown only.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
# Proposed Changes

Add a one-line `CLAUDE.md` whose only content is `@AGENTS.md`, so Claude Code (which reads `CLAUDE.md`, not `AGENTS.md`) picks up the existing agent guide. Also document the bridge in the `AGENTS.md` template: a standing instruction for anyone adapting the template, plus a bullet in the org-defaults file list noting the new file.

## Resolves

Not a bug fix; no associated issue. This is a small tooling and documentation change.

## Reason for Changes

Claude Code only loads `CLAUDE.md`. Repos that keep their guidance in `AGENTS.md` are therefore invisible to it, which matters most when working from a parent directory that holds several repos and the per-repo guide should load on demand.

I verified against the current Claude Code (2.1.158) that `AGENTS.md` is not read natively, and that a `CLAUDE.md` containing `@AGENTS.md` does load the imported content, including when the file sits in a subdirectory that loads on demand. A plain import file is used rather than a symlink, because a committed symlink does not survive Windows checkouts. Other agent tools keep reading `AGENTS.md` directly, so no content is duplicated.

## Test Coverage

This repository has no build step or test suite (prose and Markdown only). Verified manually with the installed Claude Code: a `CLAUDE.md` whose only content is `@AGENTS.md` loads the `AGENTS.md` content, while a directory containing only `AGENTS.md` does not load it.