### PR TITLE
chore: simplify and consolidate the org PR template

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,21 +1,28 @@
-# Proposed Changes
+## Summary
 
-_Describe what this Pull Request does._
+<!--
+What does this change do, and why? One or two sentences is plenty for a small
+change. For anything larger, add the motivation and context a reviewer needs:
+design decisions, alternatives considered, and screenshots/recordings for UI.
+-->
 
 ## Resolves
 
-_What GitHub issue does this resolve? If this PR fixes a bug, please link to the issue by updating the `Resolves #0`
-line below. If the bug has no associated issue, please file one first. Please do not submit bug fixes without an
-associated issue, or that only partially implement a fix._
+<!--
+Link the issue or ticket this addresses so it links/closes automatically:
+  - GitHub issue:  Resolves scratchfoundation/<repo>#123 (use the fully qualified
+                   org/repo form, not bare #123 — it stays unambiguous across forks)
+  - Jira:          Part of UEPR-456
+Use "N/A" for changes with no associated issue (e.g. small maintenance tasks).
+-->
 
-- Resolves #0
+## Testing
 
-## Reason for Changes
+<!--
+How did you verify this works? Steps, commands, or automated tests, plus
+screenshots/recordings for visible changes.
 
-_Explain why these changes should be made. Be sure to include a brief summary of the issue the Pull Request solves too._
-
-## Test Coverage
-
-_Please show how you have added tests to cover your changes, or provide step-by-step instructions for testing your
-changes. Include screenshots if applicable. When testing manually, please make sure to test in more than one browser,
-and let us know which browsers you used._
+If the change affects rendering, the editor UI, or anything user-visible, list
+the OS + browser combinations you tested (e.g. macOS/Chrome, Windows/Edge,
+iPad/Safari, Chromebook) — aim for at least two.
+-->


### PR DESCRIPTION
## Summary

Replace the four-section org default PR template with three sections: **Summary** (what + why), **Resolves**, and **Testing**.

The old template split "Proposed Changes" from "Reason for Changes" — useful for a large change, awkward filler for a small one. Merging them into Summary keeps the prompt for the *why* without forcing an empty section. Other changes: guidance moves into HTML comments so it doesn't linger in the rendered description; headings are now peers (all `##`) rather than a mixed `#`/`##` hierarchy; `Resolves` explicitly accepts GitHub issues, Jira tickets, or N/A; and `Test Coverage` becomes `Testing` (broader than just added tests) with a prompt for OS + browser coverage on user-visible changes.

(This PR's own description uses the new template, as a demo.)

## Resolves

N/A — no associated issue. Part of an effort to consolidate PR templates across the org so most repos inherit one well-maintained default instead of drifting per-repo copies. An audit of all ~105 org repos found 16 with their own template: ~12 are near-identical generic variants, and only 3 have genuinely repo-specific needs (`scratch-l10n`, `scratch-platform`, `scratchjr-webapp`, which keep theirs). Once this lands, the generic copies will be deleted so they inherit this default.

## Testing

No code change — Markdown only. Verified the rendered preview and confirmed the HTML-comment guidance is hidden in the rendered view. Not user-facing, so no browser coverage applies.